### PR TITLE
Update custom_labelbox config instead of overwriting; allow video annotation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -103,10 +103,10 @@ class RequestAnnotations(foo.Operator):
 def request_annotations(ctx, inputs, required_inputs=True):
     target_view = get_target_view(ctx, inputs)
 
-    fo.annotation_config.backends["custom_labelbox"] = {
+    fo.annotation_config.backends["custom_labelbox"].update({
         "config_cls": "custom_labelbox.LabelboxBackendConfig",
         "url": "https://labelbox.com"
-    }
+    })
     backend = LabelboxBackend("custom_labelbox")
 
     anno_key = get_new_anno_key(ctx, inputs, required_inputs=required_inputs)

--- a/custom_labelbox.py
+++ b/custom_labelbox.py
@@ -156,7 +156,7 @@ class LabelboxBackend(foua.AnnotationBackend):
 
     @property
     def supports_video_sample_fields(self):
-        return False  # @todo resolve FiftyOne bug to allow this to be True
+        return True
 
     @property
     def requires_label_schema(self):


### PR DESCRIPTION
This PR makes two changes:

* **The custom Labelbox config is partially updated instead of completely overwritten.** Setting the entire custom Labelbox config overwrote the one defined by `annotation_config.json`, which prevented us from using API keys in the JSON. This change only overwrites the specified variables, leaving others like API keys untouched. I'm not 100% sure the URL should be overwritten, but I went with the minimal change.
* **Video annotation is enabled.** Labelbox (ver. 3.59.0) seems to be giving int keys for frames again, so all is well with videos.