### PR TITLE
Add IAM integration selection

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -579,25 +579,14 @@ class LabelboxBackend(AnnotationBackend):
                 "cloud paths directly (False)"
             ),
         )
-        # TODO: Improve UX. Ideally we could pull all the available integrations
-        # and let the user choose from them with a dropdown, along with
-        # "default" for the default integration and "none" for no integration
-        inputs.bool(
-            "iam_integration_use_default",
-            default=True,
-            label="Use default Labelbox IAM integration",
-            description=(
-                "Whether to use the default IAM integration configured in "
-                "Labelbox"
-            )
-        )
         inputs.str(
             "iam_integration_name",
-            default=None,
+            default="DEFAULT",
             label="Labelbox IAM integration name",
             description=(
                 "The name of the IAM integration to associate with the created "
-                "Labelbox dataset (leave empty to use no integration)"
+                "Labelbox dataset (use \"DEFAULT\" for the default integration "
+                "or \"NONE\" for no integration)"
             )
         )
 

--- a/__init__.py
+++ b/__init__.py
@@ -579,6 +579,27 @@ class LabelboxBackend(AnnotationBackend):
                 "cloud paths directly (False)"
             ),
         )
+        # TODO: Improve UX. Ideally we could pull all the available integrations
+        # and let the user choose from them with a dropdown, along with
+        # "default" for the default integration and "none" for no integration
+        inputs.bool(
+            "iam_integration_use_default",
+            default=True,
+            label="Use default Labelbox IAM integration",
+            description=(
+                "Whether to use the default IAM integration configured in "
+                "Labelbox"
+            )
+        )
+        inputs.str(
+            "iam_integration_name",
+            default=None,
+            label="Labelbox IAM integration name",
+            description=(
+                "The name of the IAM integration to associate with the created "
+                "Labelbox dataset (leave empty to use no integration)"
+            )
+        )
 
     def parse_parameters(self, ctx, params):
         if "member" in params:

--- a/custom_labelbox.py
+++ b/custom_labelbox.py
@@ -66,8 +66,9 @@ class LabelboxBackendConfig(foua.AnnotationBackendConfig):
         upload_media (True): whether to download cloud media to your local
             cache and upload it to Labelbox (True) or to just pass the cloud
             paths directly (False)
-        iam_integration_name (None): the name of the IAM integration to
-            associate with the created Labelbox dataset
+        iam_integration_name ("DEFAULT"): the name of the IAM integration to
+            associate with the created Labelbox dataset (or "DEFAULT" for the
+            default integration or "NONE" for no integration)
     """
 
     def __init__(
@@ -81,7 +82,7 @@ class LabelboxBackendConfig(foua.AnnotationBackendConfig):
         members=None,
         classes_as_attrs=True,
         upload_media=True,
-        iam_integration_name=None,
+        iam_integration_name="DEFAULT",
         **kwargs,
     ):
         super().__init__(name, label_schema, media_field=media_field, **kwargs)
@@ -592,7 +593,7 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
         dataset_name,
         media_field="filepath",
         upload_media=True,
-        iam_integration_name=None
+        iam_integration_name="DEFAULT"
     ):
         """Uploads the media for the given samples to Labelbox.
 
@@ -611,7 +612,8 @@ class LabelboxAnnotationAPI(foua.AnnotationAPI):
                 cache and upload it to Labelbox (True) or to just pass the
                 cloud paths directly (False)
             iam_integration_name ("DEFAULT"): the name of the IAM integration
-                to associate with the created Labelbox dataset
+                to associate with the created Labelbox dataset (or "DEFAULT"
+                for the default integration or "NONE" for no integration)
         """
         media_paths, sample_ids = samples.values([media_field, "id"])
         if upload_media:


### PR DESCRIPTION
This PR lets you choose which Labelbox IAM integration to use when annotating data via the Labelbox plugin. It adds two fields:

* Use default Labelbox IAM integration (`iam_integration_use_default`): Whether to use the default IAM configured in Labelbox
* Labelbox IAM integration name (`iam_integration_name`): The name of the desired IAM integration

UX is a little janky (e.g., choosing any IAM makes no sense if the default is selected or if `upload_media == True`), but the minimum functionality is there.