### PR TITLE
support multivalue checkboxes

### DIFF
--- a/custom_labelbox.py
+++ b/custom_labelbox.py
@@ -2401,28 +2401,32 @@ def _parse_attributes(cd_list):
     attributes = {}
 
     for cd in cd_list:
-        name = cd["value"]
-        if "answer" in cd:
-            answer = cd["answer"]
-            if isinstance(answer, list):
-                # Dropdown
-                answers = [_parse_attribute(a["value"]) for a in answer]
-                if len(answers) == 1:
-                    answers = answers[0]
+        if isinstance(cd, list):
+            attributes.update(_parse_attributes(cd))
 
-                attributes[name] = answers
+        else:
+            name = cd["value"]
+            if "answer" in cd:
+                answer = cd["answer"]
+                if isinstance(answer, list):
+                    # Dropdown
+                    answers = [_parse_attribute(a["value"]) for a in answer]
+                    if len(answers) == 1:
+                        answers = answers[0]
 
-            elif isinstance(answer, dict):
-                # Radio question
-                attributes[name] = _parse_attribute(answer["value"])
-            else:
-                # Free text
-                attributes[name] = _parse_attribute(answer)
+                    attributes[name] = answers
 
-        if "answers" in cd:
-            # Checklist
-            answer = cd["answers"]
-            attributes[name] = [_parse_attribute(a["value"]) for a in answer]
+                elif isinstance(answer, dict):
+                    # Radio question
+                    attributes[name] = _parse_attribute(answer["value"])
+                else:
+                    # Free text
+                    attributes[name] = _parse_attribute(answer)
+
+            if "answers" in cd:
+                # Checklist
+                answer = cd["answers"]
+                attributes[name] = [_parse_attribute(a["value"]) for a in answer]
 
     return attributes
 


### PR DESCRIPTION
Lists of checkbox attributes were not being parsed properly. The following command:

```python
annotate(dataset, "anno_key", label_field="newf", label_type= "detections", classes= ["PLACEHOLDER"], attributes = {"classes": {"type":"checkbox", "values": ["test", "test2"]}})
```

Would result in this error:
```
fiftyone/utils/labelbox.py:2369, in _parse_attributes(cd_list)
   2366 attributes = {}
   2368 for cd in cd_list:
-> 2369     name = cd["value"]
   2370     if "answer" in cd:
   2371         answer = cd["answer"]

TypeError: list indices must be integers or slices, not str
```

This PR parses theses attribute lists properly.