### PR TITLE
Fix member argument

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -595,7 +595,7 @@ class LabelboxBackend(AnnotationBackend):
 
     def parse_parameters(self, ctx, params):
         if "member" in params:
-            params["member"] = [
+            params["members"] = [
                 (m["email"], m["role"]) for m in params["member"]
             ]
 


### PR DESCRIPTION
This PR fixes a bug where the specified members don't get added to the Labelbox project. Specifically, by renaming the "member" argument to "members", the Labelbox backend configuration can now find the correct argument and create the Labelbox project accordingly.