### PR TITLE
Update additional members references

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -595,7 +595,7 @@ class LabelboxBackend(AnnotationBackend):
 
     def parse_parameters(self, ctx, params):
         if "member" in params:
-            params["member"] = [
+            params["members"] = [
                 (m["email"], m["role"]) for m in params["member"]
             ]
 

--- a/__init__.py
+++ b/__init__.py
@@ -555,7 +555,7 @@ class LabelboxBackend(AnnotationBackend):
             description="A name to assign to the generated project",
         )
         inputs.list(
-            "member",
+            "members",
             self.build_member(required_inputs=required_inputs),
             default=None,
             label="Members",
@@ -594,9 +594,9 @@ class LabelboxBackend(AnnotationBackend):
         )
 
     def parse_parameters(self, ctx, params):
-        if "member" in params:
+        if "members" in params:
             params["members"] = [
-                (m["email"], m["role"]) for m in params["member"]
+                (m["email"], m["role"]) for m in params["members"]
             ]
 
     def build_member(self, required_inputs=True):


### PR DESCRIPTION
Ryan found a but with the `member` parameter which should be called `members` in order for the Labelbox backend to pick it up. This PR updates all references to this parameter to be `members`.