### PR TITLE
Fix inject secrets for load and delete ops

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -685,6 +685,14 @@ class LoadAnnotations(foo.Operator):
 
 
 def load_annotations(ctx, inputs):
+    if "custom_labelbox" not in fo.annotation_config.backends:
+        fo.annotation_config.backends["custom_labelbox"] = {}
+
+    fo.annotation_config.backends["custom_labelbox"].update({
+        "config_cls": "custom_labelbox.LabelboxBackendConfig",
+        "url": "https://labelbox.com"
+    })
+
     anno_keys = ctx.dataset.list_annotation_runs()
 
     if not anno_keys:
@@ -896,6 +904,14 @@ class DeleteAnnotationRun(foo.Operator):
         foo.execute_operator(self.uri, ctx, params=params)
 
     def resolve_input(self, ctx):
+        if "custom_labelbox" not in fo.annotation_config.backends:
+            fo.annotation_config.backends["custom_labelbox"] = {}
+
+        fo.annotation_config.backends["custom_labelbox"].update({
+            "config_cls": "custom_labelbox.LabelboxBackendConfig",
+            "url": "https://labelbox.com"
+        })
+
         inputs = types.Object()
 
         anno_key = get_anno_key(ctx, inputs, show_default=False)


### PR DESCRIPTION
This PR fixes an edge case where the plugin tries to inject Labelbox secrets before the `request_annotations` op is called (e.g., if a user tries to load annotations soon after the plugin container is restarted).

The plugin needs the custom Labelbox backend to be configured before it can inject secrets; however, this configuration only happens when the `request_annotations` op is called. This PR fixes that by running the configuration code in `load_annotations` and `delete_annotation_run`.

Side note: To match `request_annotations` as closely as possible, the additional code runs within each op's `resolve_input()` method.